### PR TITLE
Bug related to a re-equip animation for a Signed Album when opening and closing inventory fixed

### DIFF
--- a/common/src/main/java/io/github/mortuusars/exposure/world/item/AbstractAlbumItem.java
+++ b/common/src/main/java/io/github/mortuusars/exposure/world/item/AbstractAlbumItem.java
@@ -1,0 +1,11 @@
+package io.github.mortuusars.exposure.world.item;
+
+import net.minecraft.world.item.ItemStack;
+
+public interface AbstractAlbumItem {
+
+    default boolean shouldPlayEquipAnimation(ItemStack oldStack, ItemStack newStack) {
+        return oldStack.getItem() != newStack.getItem();
+    }
+
+}

--- a/common/src/main/java/io/github/mortuusars/exposure/world/item/AlbumItem.java
+++ b/common/src/main/java/io/github/mortuusars/exposure/world/item/AlbumItem.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-public class AlbumItem extends Item {
+public class AlbumItem extends Item implements AbstractAlbumItem{
     public AlbumItem(Properties properties) {
         super(properties);
     }

--- a/common/src/main/java/io/github/mortuusars/exposure/world/item/SignedAlbumItem.java
+++ b/common/src/main/java/io/github/mortuusars/exposure/world/item/SignedAlbumItem.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class SignedAlbumItem extends Item {
+public class SignedAlbumItem extends Item implements AbstractAlbumItem{
     public SignedAlbumItem(Properties properties) {
         super(properties);
     }

--- a/fabric/src/main/java/io/github/mortuusars/exposure/fabric/mixin/AlbumItemFabricMixin.java
+++ b/fabric/src/main/java/io/github/mortuusars/exposure/fabric/mixin/AlbumItemFabricMixin.java
@@ -1,20 +1,20 @@
 package io.github.mortuusars.exposure.fabric.mixin;
 
-import io.github.mortuusars.exposure.world.item.AlbumItem;
+import io.github.mortuusars.exposure.world.item.AbstractAlbumItem;
 import net.fabricmc.fabric.api.item.v1.FabricItem;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = AlbumItem.class, remap = false)
+@Mixin(value = FabricItem.class, remap = false)
 public abstract class AlbumItemFabricMixin implements FabricItem {
-    @Shadow
-    abstract boolean shouldPlayEquipAnimation(ItemStack oldStack, ItemStack newStack);
 
-    @Override
-    public boolean allowComponentsUpdateAnimation(Player player, InteractionHand hand, ItemStack oldStack, ItemStack newStack) {
-        return shouldPlayEquipAnimation(oldStack, newStack);
+    @Inject(method = "allowComponentsUpdateAnimation", at = @At("HEAD"), cancellable = true)
+    public void allowComponentsUpdateAnimation(Player player, InteractionHand hand, ItemStack oldStack, ItemStack newStack, CallbackInfoReturnable<Boolean> cir) {
+        if (((Object) this) instanceof AbstractAlbumItem albumItemCommon) cir.setReturnValue(albumItemCommon.shouldPlayEquipAnimation(oldStack, newStack));
     }
 }

--- a/fabric/src/main/java/io/github/mortuusars/exposure/fabric/mixin/AlbumItemFabricMixin.java
+++ b/fabric/src/main/java/io/github/mortuusars/exposure/fabric/mixin/AlbumItemFabricMixin.java
@@ -4,17 +4,16 @@ import io.github.mortuusars.exposure.world.item.AbstractAlbumItem;
 import net.fabricmc.fabric.api.item.v1.FabricItem;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = FabricItem.class, remap = false)
+@Mixin(value = Item.class, remap = false)
 public abstract class AlbumItemFabricMixin implements FabricItem {
 
-    @Inject(method = "allowComponentsUpdateAnimation", at = @At("HEAD"), cancellable = true)
-    public void allowComponentsUpdateAnimation(Player player, InteractionHand hand, ItemStack oldStack, ItemStack newStack, CallbackInfoReturnable<Boolean> cir) {
-        if (((Object) this) instanceof AbstractAlbumItem albumItemCommon) cir.setReturnValue(albumItemCommon.shouldPlayEquipAnimation(oldStack, newStack));
+    @Override
+    public boolean allowComponentsUpdateAnimation(Player player, InteractionHand hand, ItemStack oldStack, ItemStack newStack) {
+        if (((Object) this) instanceof AbstractAlbumItem albumItemCommon) return albumItemCommon.shouldPlayEquipAnimation(oldStack, newStack);
+        else return true;
     }
 }

--- a/neoforge/src/main/java/io/github/mortuusars/exposure/neoforge/mixin/AlbumItemNeoForgeMixin.java
+++ b/neoforge/src/main/java/io/github/mortuusars/exposure/neoforge/mixin/AlbumItemNeoForgeMixin.java
@@ -1,18 +1,18 @@
 package io.github.mortuusars.exposure.neoforge.mixin;
 
 import io.github.mortuusars.exposure.world.item.AbstractAlbumItem;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.extensions.IItemExtension;
+import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = IItemExtension.class, remap = false)
+@Mixin(value = Item.class, remap = false)
 public abstract class AlbumItemNeoForgeMixin implements IItemExtension {
 
-    @Inject(method = "shouldCauseReequipAnimation", at = @At("HEAD"), cancellable = true)
-    public void shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged, CallbackInfoReturnable<Boolean> cir) {
-        if (((Object) this) instanceof AbstractAlbumItem albumItemCommon) cir.setReturnValue(albumItemCommon.shouldPlayEquipAnimation(oldStack, newStack));
+    @Override
+    public boolean shouldCauseReequipAnimation(@NotNull ItemStack oldStack, @NotNull ItemStack newStack, boolean slotChanged) {
+        if (((Object) this) instanceof AbstractAlbumItem albumItemCommon) return albumItemCommon.shouldPlayEquipAnimation(oldStack, newStack);
+        else return !oldStack.equals(newStack);
     }
 }

--- a/neoforge/src/main/java/io/github/mortuusars/exposure/neoforge/mixin/AlbumItemNeoForgeMixin.java
+++ b/neoforge/src/main/java/io/github/mortuusars/exposure/neoforge/mixin/AlbumItemNeoForgeMixin.java
@@ -1,19 +1,18 @@
 package io.github.mortuusars.exposure.neoforge.mixin;
 
-import io.github.mortuusars.exposure.world.item.AlbumItem;
+import io.github.mortuusars.exposure.world.item.AbstractAlbumItem;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.common.extensions.IItemExtension;
-import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-@Mixin(value = AlbumItem.class, remap = false)
+@Mixin(value = IItemExtension.class, remap = false)
 public abstract class AlbumItemNeoForgeMixin implements IItemExtension {
-    @Shadow
-    abstract boolean shouldPlayEquipAnimation(ItemStack oldStack, ItemStack newStack);
 
-    @Override
-    public boolean shouldCauseReequipAnimation(@NotNull ItemStack oldStack, @NotNull ItemStack newStack, boolean slotChanged) {
-        return shouldPlayEquipAnimation(oldStack, newStack);
+    @Inject(method = "shouldCauseReequipAnimation", at = @At("HEAD"), cancellable = true)
+    public void shouldCauseReequipAnimation(ItemStack oldStack, ItemStack newStack, boolean slotChanged, CallbackInfoReturnable<Boolean> cir) {
+        if (((Object) this) instanceof AbstractAlbumItem albumItemCommon) cir.setReturnValue(albumItemCommon.shouldPlayEquipAnimation(oldStack, newStack));
     }
 }


### PR DESCRIPTION
Changes in a nutshell:
Moved a method shouldPlayEquipAnimation from an AlbumItem to an interface AbstractAlbumItem, then implemented it in an AlbumItem and a SignedAlbumItem, also changing 2 related mixins (fabric and neoforge ones) to use the method from an interface instead. (They also now inject into a FabricItem for a fabric mixin and a IItemExtension for neoforge mixin instead of AlbumItem). 

P.S - sorry for a second pull request, didn't test the first one, but this I did.