### PR TITLE
fixes item frame photograph renderer

### DIFF
--- a/common/src/main/java/io/github/mortuusars/exposure/client/render/ItemFramePhotographRenderer.java
+++ b/common/src/main/java/io/github/mortuusars/exposure/client/render/ItemFramePhotographRenderer.java
@@ -32,7 +32,7 @@ public class ItemFramePhotographRenderer {
 
         poseStack.mulPose(Axis.ZP.rotationDegrees(180.0F));
         poseStack.scale(scale, scale, scale);
-        poseStack.translate(-0.5, -0.5, 10);
+        poseStack.translate(-0.5, -0.5, 0);
 
         ExposureClient.photographRenderer().renderPhotograph(poseStack, bufferSource, item, stack,
                 false, false, packedLight, 255, 255, 255, 255);


### PR DESCRIPTION
Simple fix that fixes photograph rendering in item frames.

Old behavior (photo is behind the item frame):
![2025-05-20_23 07 36](https://github.com/user-attachments/assets/eeac672e-3782-47f3-b69b-88868a7cfdc4)

New behavior:
![2025-05-20_23 08 27](https://github.com/user-attachments/assets/14a3f5b6-4eb3-4e24-bdfe-e187a1b9a19c)
