### PR TITLE
better BackgroundScreenshotCaptureTask compatibility

### DIFF
--- a/common/src/main/java/io/github/mortuusars/exposure/Config.java
+++ b/common/src/main/java/io/github/mortuusars/exposure/Config.java
@@ -395,7 +395,7 @@ public class Config {
                                 "Format: '[\"mod_id\", \"mod_id\"]'. Default: [" + String.join(", ", Exposure.MODS_REQUIRING_DIRECT_CAPTURE) + "]")
                         .defineList("force_direct_capture_mods", () -> Exposure.MODS_REQUIRING_DIRECT_CAPTURE, () -> "mod_id", o -> true);
                 DIRECT_CAPTURE_DELAY_FRAMES = builder
-                        .comment("Delay in frames before capturing an image if 'direct_capture' method is in use (or if Oculus or Iris is installed).",
+                        .comment("Delay in frames before capturing an image if 'direct_capture' method is in use.",
                                 "Set to higher value when leftovers of GUI elements (such as nameplates) are visible on the images",
                                 "(some shaders have temporal effects that take several frames to disappear fully)")
                         .defineInRange("direct_capture_delay_frames", 0, 0, 100);

--- a/common/src/main/java/io/github/mortuusars/exposure/Exposure.java
+++ b/common/src/main/java/io/github/mortuusars/exposure/Exposure.java
@@ -79,7 +79,7 @@ public class Exposure {
     public static final String ID = "exposure";
     public static final Logger LOGGER = LogUtils.getLogger();
 
-    public static final List<String> MODS_REQUIRING_DIRECT_CAPTURE = List.of("iris", "oculus", "effective", "distanthorizons");
+    public static final List<String> MODS_REQUIRING_DIRECT_CAPTURE = List.of("veil");
     public static final int MAX_ENTITIES_IN_FRAME = 10;
 
     public static void init() {

--- a/common/src/main/java/io/github/mortuusars/exposure/mixin/client/MinecraftMixin.java
+++ b/common/src/main/java/io/github/mortuusars/exposure/mixin/client/MinecraftMixin.java
@@ -1,7 +1,9 @@
 package io.github.mortuusars.exposure.mixin.client;
 
+import com.mojang.blaze3d.pipeline.RenderTarget;
 import io.github.mortuusars.exposure.client.camera.CameraClient;
 import io.github.mortuusars.exposure.client.camera.viewfinder.ViewfinderCameraControlsScreen;
+import io.github.mortuusars.exposure.client.capture.task.BackgroundScreenshotCaptureTask;
 import io.github.mortuusars.exposure.event.ClientEvents;
 import io.github.mortuusars.exposure.network.Packets;
 import io.github.mortuusars.exposure.network.packet.serverbound.ActiveCameraReleaseC2SP;
@@ -55,6 +57,13 @@ public abstract class MinecraftMixin {
     void onLevelUnload(ClientLevel newLevel, ReceivingLevelScreen.Reason reason, CallbackInfo ci) {
         if (level != null) {
             ClientEvents.levelUnloaded();
+        }
+    }
+
+    @Inject(method = "getMainRenderTarget", at = @At("HEAD"), cancellable = true)
+    void onGetMainRenderTarget(CallbackInfoReturnable<RenderTarget> cir) {
+        if (BackgroundScreenshotCaptureTask.capturing && BackgroundScreenshotCaptureTask.renderTarget != null) {
+            cir.setReturnValue(BackgroundScreenshotCaptureTask.renderTarget);
         }
     }
 


### PR DESCRIPTION
fixes compatibility for iris, oculus (well, NeOculus), and distant horizons in my testing.
dunno if it introduces other issues, but I don't think it should.

also changes effective to veil in the MODS_REQUIRING_DIRECT_CAPTURE list, since effective uses it, and these [two](https://modrinth.com/mod/light-the-way) [mods](https://modrinth.com/mod/simple-flashlight) that also use veil cause the same issue.